### PR TITLE
Add async/await API support

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,21 @@ networkManager.callApi(responseType: UserData.self) { result in
 ```
 The `EXNetworkManager` accepts a generic API element. This will ensure we can only pass in the proper data and the manager will return a proper result of the codable data we provided in function signature
 
+### Async/Await
+
+Swift Concurrency is also supported from iOS&nbsp;13 and above. The framework exposes
+`async` variants of `callApi` to make network requests without callbacks.
+
+``` swift
+let manager = EXNetworkManager<JSONPlaceHolderApi>(api: .user(id: 1))
+do {
+    let userData: UserData = try await manager.callApi(responseType: UserData.self)
+    print(userData.name)
+} catch {
+    print(error)
+}
+```
+
 ## Adding SSL Pinning 
 
 EXNetworkManager has built in capability to execute API call with SSL Pinning from certificate file.

--- a/Sources/EXNetworkLayer/HTTPClient/HTTPClient.swift
+++ b/Sources/EXNetworkLayer/HTTPClient/HTTPClient.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public protocol HTTPClient {
     func httpDataTask(with request: URLRequest, completionHandler: @escaping @Sendable (Data?, URLResponse?, Error?) -> Void) -> URLSessionDataTask

--- a/Sources/EXNetworkLayer/HTTPClient/MockHTTPClient.swift
+++ b/Sources/EXNetworkLayer/HTTPClient/MockHTTPClient.swift
@@ -5,7 +5,10 @@
 //  Created by Abhijith Pm on 08/11/22.
 //
 
-import UIKit
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public enum MockData {
     case data(_ data: Data)

--- a/Sources/EXNetworkLayer/NetworkManager/BasicRequest+Async.swift
+++ b/Sources/EXNetworkLayer/NetworkManager/BasicRequest+Async.swift
@@ -1,0 +1,65 @@
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+@available(iOS 13.0, macOS 10.15, tvOS 13.0, watchOS 6.0, *)
+public extension BasicRequest {
+    func callApi<U: Decodable>(responseType: U.Type) async throws -> U {
+        guard let request = try? requestProvider.request() else {
+            throw BasicRequestError.generalError
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            session.httpDataTask(with: request) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: BasicRequestError.apiResponseError(error: error))
+                    return
+                }
+                guard let data = data else {
+                    continuation.resume(throwing: BasicRequestError.noDataPresentInApi(error))
+                    return
+                }
+                if self.api.shouldLog {
+                    self.api.log(self.api,
+                                 level: error == nil ? .debug : .error,
+                                 data: data,
+                                 error: error)
+                }
+                guard let value = try? self.decoder.decode(responseType, from: data) else {
+                    continuation.resume(throwing: BasicRequestError.parsingfailed)
+                    return
+                }
+                continuation.resume(returning: value)
+            }.resume()
+        }
+    }
+
+    func callApi<U: Decodable>(responseType: [U].Type) async throws -> [U] {
+        guard let request = try? requestProvider.request() else {
+            throw BasicRequestError.generalError
+        }
+        return try await withCheckedThrowingContinuation { continuation in
+            session.httpDataTask(with: request) { data, response, error in
+                if let error = error {
+                    continuation.resume(throwing: BasicRequestError.apiResponseError(error: error))
+                    return
+                }
+                guard let data = data else {
+                    continuation.resume(throwing: BasicRequestError.noDataPresentInApi(error))
+                    return
+                }
+                if self.api.shouldLog {
+                    self.api.log(self.api,
+                                 level: error == nil ? .debug : .error,
+                                 data: data,
+                                 error: error)
+                }
+                guard let value = try? self.decoder.decode(responseType, from: data) else {
+                    continuation.resume(throwing: BasicRequestError.parsingfailed)
+                    return
+                }
+                continuation.resume(returning: value)
+            }.resume()
+        }
+    }
+}

--- a/Sources/EXNetworkLayer/NetworkManager/Cacher/EXCodableCacher+Disk.swift
+++ b/Sources/EXNetworkLayer/NetworkManager/Cacher/EXCodableCacher+Disk.swift
@@ -5,7 +5,7 @@
 //  Created by Abhijith Pm on 09/11/22.
 //
 
-import UIKit
+import Foundation
 
 // MARK: Functions to Create, Read cache saved to disk
 extension EXCodableCacher {

--- a/Sources/EXNetworkLayer/NetworkManager/Cacher/EXCodableCacher+inMemory.swift
+++ b/Sources/EXNetworkLayer/NetworkManager/Cacher/EXCodableCacher+inMemory.swift
@@ -5,7 +5,7 @@
 //  Created by Abhijith Pm on 09/11/22.
 //
 
-import UIKit
+import Foundation
 
 // MARK: Functions to save and retreive data into memory
 extension EXCodableCacher {

--- a/Sources/EXNetworkLayer/NetworkManager/EXNetworkManager.swift
+++ b/Sources/EXNetworkLayer/NetworkManager/EXNetworkManager.swift
@@ -5,7 +5,10 @@
 //  Created by Abhijith Pm on 08/11/22.
 //
 
-import UIKit
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public class EXNetworkManager<T: API>: BasicRequest {
     

--- a/Sources/EXNetworkLayer/NetworkManager/NetworkManager.swift
+++ b/Sources/EXNetworkLayer/NetworkManager/NetworkManager.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public enum BasicRequestError: Error {
     case requestCreationFailed(RequestCreatorErrors)

--- a/Sources/EXNetworkLayer/NetworkManager/SSLPinningHandler/SSLPinningHandler.swift
+++ b/Sources/EXNetworkLayer/NetworkManager/SSLPinningHandler/SSLPinningHandler.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 class SSLPinningHandler: NSObject, URLSessionDelegate {
 

--- a/Sources/EXNetworkLayer/RequestBody/EXRequestBodyCreator.swift
+++ b/Sources/EXNetworkLayer/RequestBody/EXRequestBodyCreator.swift
@@ -5,7 +5,7 @@
 //  Created by Abhijith Pm on 08/11/22.
 //
 
-import UIKit
+import Foundation
 
 public class EXRequestBodyCreator: RequestBodyContentCreator {
     public var api: API

--- a/Sources/EXNetworkLayer/RequestProvider/RequestProvider.swift
+++ b/Sources/EXNetworkLayer/RequestProvider/RequestProvider.swift
@@ -6,6 +6,9 @@
 //
 
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 public enum RequestCreatorErrors: Error {
     // Errors while creating the URL


### PR DESCRIPTION
## Summary
- add `BasicRequest` async functions
- import `FoundationNetworking` on Linux
- document async call usage in README

## Testing
- `swift test` *(fails: swift-corelibs-foundation missing Security)*

------
https://chatgpt.com/codex/tasks/task_e_683e609be14c832286e8c2298e5ef6d0